### PR TITLE
V2 general improvements (wip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [2.0.0] - 11-07-2024
+## [2.0.0] - 25-07-2024
 
 ### Added
  - Added a default ActionContext.json to use in the DebugStart script. This provides test data for local debugging and can be directly extracted from HelloID, ensuring consistent object handling locally and in HelloID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,20 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [1.3.0] - 03-07-2024
+## [2.0.0] - 11-07-2024
 
 ### Added
- - Added default ActionContext for easier debugging
+ - Added a default ActionContext.json to use in the DebugStart script. This provides test data for local debugging and can be directly extracted from HelloID, ensuring consistent object handling locally and in HelloID
 
 ### Changed
  - Moved the processing DryRun block one level closer to the actual web call. To skip only the web call in the target system in preview mode. To remove the difference between a preview run and actual enforcement. And test more connector code in Preview mode.
- - Changed the debugStart to use ActionContext.json instead of Powershell Object
- - Some textual improvements
+ - Changed the debugStart to use ActionContext.json instead of Powershell Object.
+ - Some textual improvements.
 
 ### Removed
-- Removed explicit DryRun messages for preview mode
-- Removed the Invoke-<connectorName>RestMethod from the template
-- Removed Person.DisplayName from logging
+- Removed explicit DryRun messages for preview mode.
+- Removed the Invoke-<connectorName>RestMethod from the template.
+- Removed Person.DisplayName from logging.
 - Removed Start EndDate from FieldMapping.
 
 ## [1.2.0] - 18-04-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ All notable changes to this project will be documented in this file. The format 
  - Moved the processing DryRun block one level closer to the actual web call. To skip only the web call in the target system in preview mode. To remove the difference between a preview run and actual enforcement. And test more connector code in Preview mode.
  - Changed the debugStart to use ActionContext.json instead of Powershell Object.
  - Some textual improvements.
+ - Moved explicit DryRun messages for preview mode, to the `else` condition after the (-not dryrun block).
 
 ### Removed
-- Removed explicit DryRun messages for preview mode.
 - Removed the Invoke-<connectorName>RestMethod from the template.
 - Removed Person.DisplayName from logging.
 - Removed Start EndDate from FieldMapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,18 @@ All notable changes to this project will be documented in this file. The format 
 ## [1.3.0] - 03-07-2024
 
 ### Added
-
- -
+ - Added default ActionContext for easier debugging
 
 ### Changed
- - Moved the processing DryRun block one level deeper to only skip the actual web call to the target system in preview mode.
+ - Moved the processing DryRun block one level closer to the actual web call. To skip only the web call in the target system in preview mode. To remove the difference between a preview run and actual enforcement. And test more connector code in Preview mode.
+ - Changed the debugStart to use ActionContext.json instead of Powershell Object
+ - Some textual improvements
 
 ### Removed
 - Removed explicit DryRun messages for preview mode
 - Removed the Invoke-<connectorName>RestMethod from the template
+- Removed Person.DisplayName from logging
+- Removed Start EndDate from FieldMapping.
 
 ## [1.2.0] - 18-04-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.3.0] - 03-07-2024
+
+### Added
+
+ -
+
+### Changed
+ - Moved the processing DryRun block one level deeper to only skip the actual web call to the target system in preview mode.
+
+### Removed
+- Removed explicit DryRun messages for preview mode
+- Removed the Invoke-<connectorName>RestMethod from the template
+
 ## [1.2.0] - 18-04-2024
 
 ### Added
@@ -16,7 +29,7 @@ All notable changes to this project will be documented in this file. The format 
 - Renamed the header in file `revokePermission.ps1` from 'Revoke' to  'RevokePermission-Group' to match the file name and folder change.
 - Renamed the header in file `permissions.ps1` from 'Permissions' to  'Permissions-Group' to match the file name and folder change.
 - Renamed the header in file `resources.ps1` from 'Resources' to  'Resources-Group' to match the file name and folder change.
-  
+
 - Moved the following files to the _permissions/groups_ folder:
   - grantPermission.ps1
   - revokePermission.ps1
@@ -34,7 +47,7 @@ All notable changes to this project will be documented in this file. The format 
   - Adjusted the dryRun information message to display `$actionContext.References.Permission.DisplayName` instead of `$actionContext.References.Permission.Reference`.
   - Adjusted the information message inside the `if (-not($actionContext.DryRun -eq $true))` block to display both the `$actionContext.References.Permission.DisplayName` and `$actionContext.References.Permission.Reference`.
   - Renamed 'entitlement' to 'permission' to be consistent in all informational and audit messages.
-  
+
 ### Removed
 
 - Removed line `Write-Information 'Adding body to request'` from the `Invoke-{connectorName}RestMethod` function in each of the __*ps1*__ files.

--- a/README.md
+++ b/README.md
@@ -185,41 +185,40 @@ if ($null -eq $correlatedAccount){
     $outputContext.AccountReference = $correlatedAccount.id
 }
 
-# Add a message and the result of each of the validations showing what will happen during enforcement
-if ($actionContext.DryRun -eq $true) {
-    Write-Information "[DryRun] $action {connectorName} account for: [$($personContext.Person.DisplayName)], will be executed during enforcement"
-}
-
 # Process
-if (-not($actionContext.DryRun -eq $true)) {
-    switch ($action) {
-        'CreateAccount' {
-            Write-Information 'Creating and correlating {connectorName} account'
+  switch ($action) {
+      'CreateAccount' {
+          Write-Information 'Creating and correlating {connectorName} account'
 
-            # Make sure to test with special characters and if needed; add utf8 encoding.
+          # Make sure to test with special characters and if needed; add utf8 encoding.
+          if (-not($actionContext.DryRun -eq $true)) {
+              # Write Create logic here
+              # $createdAccount = Invoke-RestMethod @splatParams
+              $outputContext.Data = $createdAccount
+              $outputContext.AccountReference = ''
+          }
 
-            $outputContext.AccountReference = ''
-            $outputContext.AccountCorrelated = $true
-            $auditLogMessage = "Create account was successful. AccountReference is: [$($outputContext.AccountReference)"
-            break
-        }
+          $outputContext.AccountReference = ''
+          $outputContext.AccountCorrelated = $true
+          $auditLogMessage = "Create account was successful. AccountReference is: [$($outputContext.AccountReference)"
+          break
+      }
 
-        'CorrelateAccount' {
-            Write-Information 'Correlating {connectorName} account'
-            $outputContext.AccountReference = ''
-            $outputContext.AccountCorrelated = $true
-            $auditLogMessage = "Correlated account: [$($correlatedAccount.ExternalId)] on field: [$($correlationField)] with value: [$($correlationValue)]"
-            break
-        }
-    }
+      'CorrelateAccount' {
+          Write-Information 'Correlating {connectorName} account'
+          $outputContext.AccountReference = ''
+          $outputContext.AccountCorrelated = $true
+          $auditLogMessage = "Correlated account: [$($correlatedAccount.ExternalId)] on field: [$($correlationField)] with value: [$($correlationValue)]"
+          break
+      }
+  }
 
-    $outputContext.success = $true
-    $outputContext.AuditLogs.Add([PSCustomObject]@{
-        Action  = $action
-        Message = $auditLogMessage
-        IsError = $false
-    })
-}
+  $outputContext.success = $true
+  $outputContext.AuditLogs.Add([PSCustomObject]@{
+      Action  = $action
+      Message = $auditLogMessage
+      IsError = $false
+  })
 ```
 
 #### If the managed account does not exist

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ This comparison between `$outputContext.Data` vs `$outputContext.PreviousData` i
 
 Debugging is _arguably_ one of the most complex topics in any programming / scripting language.
 
-The templates also comes with a __debugStart.ps1__, __config.json__, __actionContext.json__ and __demoPerson.json__ in the _test_ folder. They allows you to easily debug your scripts. You can _mock_ variables such as the `$personContext`, `$actionContext` and all built-in variables in HelloID you need. By mocking these variables, you can easily test your scripts under a variety of conditions, without having to worry about external dependencies or data sources.
+The templates also comes with a __debugStart.ps1__, __actionContext.json__ and __demoPerson.json__ in the _test_ folder. They allow you to easily debug your scripts. You can _mock_ variables such as the `$personContext`, `$actionContext` and all built-in variables in HelloID you need. By mocking these variables, you can easily test your scripts under a variety of conditions, without having to worry about external dependencies or data sources.
 
 To mock a variable in `debugStart.ps1`, simply specify the value you want to use for that variable in the mock object at the top of the script.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ We can't wait to see the amazing PowerShell connectors you'll build with these t
 | ./permissions/groups/revokePermission.ps1 | PowerShell _revoke_ lifecycle action                                   |
 | ./permissions/groups/permissions.ps1      | PowerShell _permissions_ lifecycle action                              |
 | ./resources/groups/resources.ps1          | PowerShell _resources_ lifecycle action                                |
-| ./test.config.json                        | Prefilled _config.json_ file for easy debugging                        |
+| ./test/config.json                        | Prefilled _config.json_ file for easy debugging                        |
+| ./test/actionContext.json                 | Prefilled _actionContext.json_ file for easy debugging                        |
 | ./test/demoPerson.json                    | Prefilled _demoPerson.json_ for easy debugging                         |
 | ./test/debugStart.ps1                     | Default _debugStart.ps1_ for easy debugging                            |
 | .gitignore                                | `gitignore` excluding the `test` folder when pushing commits to GitHub |
@@ -258,7 +259,7 @@ This comparison between `$outputContext.Data` vs `$outputContext.PreviousData` i
 
 Debugging is _arguably_ one of the most complex topics in any programming / scripting language.
 
-The templates also comes with a __debugStart.ps1__, __config.json__ and __demoPerson.json__ in the _test_ folder. They allows you to easily debug your scripts. You can _mock_ variables such as the `$personContext`, `$actionContext` and all built-in variables in HelloID you need. By mocking these variables, you can easily test your scripts under a variety of conditions, without having to worry about external dependencies or data sources.
+The templates also comes with a __debugStart.ps1__, __config.json__, __actionContext.json__ and __demoPerson.json__ in the _test_ folder. They allows you to easily debug your scripts. You can _mock_ variables such as the `$personContext`, `$actionContext` and all built-in variables in HelloID you need. By mocking these variables, you can easily test your scripts under a variety of conditions, without having to worry about external dependencies or data sources.
 
 To mock a variable in `debugStart.ps1`, simply specify the value you want to use for that variable in the mock object at the top of the script.
 

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -2,6 +2,7 @@
 
 # Exclude test folder
 test/
+test/actionContext.json
 
 # VSCode files (for those working on multiple projects)
 .vscode/*

--- a/target/README.md
+++ b/target/README.md
@@ -10,7 +10,7 @@
 
 ## Table of contents
 
-- [HelloID-Conn-Prov-Target-{connectorName}](#helloid-conn-prov-target-{connectorName})
+- [HelloID-Conn-Prov-Target-{connectorName}](#helloid-conn-prov-target-connectorname)
   - [Table of contents](#table-of-contents)
   - [Introduction](#introduction)
   - [Getting started](#getting-started)
@@ -67,7 +67,7 @@ To properly setup the correlation:
     | ------------------------- | --------------------------------- |
     | Enable correlation        | `True`                            |
     | Person correlation field  | `PersonContext.Person.ExternalId` |
-    | Account correlation field | ``                                |
+    | Account correlation field | `Employeenumber`                  |
 
 > [!TIP]
 > _For more information on correlation, please refer to our correlation [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems/correlation.html) pages_.

--- a/target/README.md
+++ b/target/README.md
@@ -1,4 +1,3 @@
-
 # HelloID-Conn-Prov-Target-{connectorName}
 
 > [!IMPORTANT]
@@ -35,19 +34,19 @@ _HelloID-Conn-Prov-Target-{connectorName}_ is a _target_ connector. _{connectorN
 
 The following lifecycle actions are available:
 
-| Action                 | Description                                      |
-| ---------------------- | ------------------------------------------------ |
-| create.ps1             | PowerShell _create_ lifecycle action             |
-| delete.ps1             | PowerShell _delete_ lifecycle action             |
-| disable.ps1            | PowerShell _disable_ lifecycle action            |
-| enable.ps1             | PowerShell _enable_ lifecycle action             |
-| update.ps1             | PowerShell _update_ lifecycle action             |
-| permissions/groups/grantPermission.ps1    | PowerShell _grant_ lifecycle action              |
-| permissions/groups/revokePermission.ps1   | PowerShell _revoke_ lifecycle action             |
-| permissions/groups/permissions.ps1        | PowerShell _permissions_ lifecycle action        |
-| resources/groups/resources.ps1          | PowerShell _resources_ lifecycle action          |
-| configuration.json     | Default _configuration.json_ |
-| fieldMapping.json      | Default _fieldMapping.json_   |
+| Action                                  | Description                               |
+| --------------------------------------- | ----------------------------------------- |
+| create.ps1                              | PowerShell _create_ lifecycle action      |
+| delete.ps1                              | PowerShell _delete_ lifecycle action      |
+| disable.ps1                             | PowerShell _disable_ lifecycle action     |
+| enable.ps1                              | PowerShell _enable_ lifecycle action      |
+| update.ps1                              | PowerShell _update_ lifecycle action      |
+| permissions/groups/grantPermission.ps1  | PowerShell _grant_ lifecycle action       |
+| permissions/groups/revokePermission.ps1 | PowerShell _revoke_ lifecycle action      |
+| permissions/groups/permissions.ps1      | PowerShell _permissions_ lifecycle action |
+| resources/groups/resources.ps1          | PowerShell _resources_ lifecycle action   |
+| configuration.json                      | Default _configuration.json_              |
+| fieldMapping.json                       | Default _fieldMapping.json_               |
 
 ## Getting started
 
@@ -67,7 +66,7 @@ To properly setup the correlation:
     | ------------------------- | --------------------------------- |
     | Enable correlation        | `True`                            |
     | Person correlation field  | `PersonContext.Person.ExternalId` |
-    | Account correlation field | `Employeenumber`                  |
+    | Account correlation field | `EmployeeNumber`                  |
 
 > [!TIP]
 > _For more information on correlation, please refer to our correlation [documentation](https://docs.helloid.com/en/provisioning/target-systems/powershell-v2-target-systems/correlation.html) pages_.

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -7,7 +7,7 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Resolve- { connectorName }Error {
+function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -90,7 +90,7 @@ try {
                 # Write Create logic here
                 $createdAccount = Invoke-RestMethod @splatParamsCreate
                 $outputContext.Data = $createdAccount
-                $outputContext.AccountReference = ''
+                $outputContext.AccountReference = $createdAccount.Id
             }
             $auditLogMessage = "Create account was successful. AccountReference is: [$($outputContext.AccountReference)]"
             break
@@ -100,7 +100,7 @@ try {
             Write-Information 'Correlating {connectorName} account'
 
             $outputContext.Data = $correlatedAccount
-            $outputContext.AccountReference = $correlatedAccount
+            $outputContext.AccountReference = $correlatedAccount.Id
             $outputContext.AccountCorrelated = $true
             $auditLogMessage = "Correlated account: [$($outputContext.AccountReference)] on field: [$($correlationField)] with value: [$($correlationValue)]"
             break
@@ -118,7 +118,7 @@ try {
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
         $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
-        $errorObj = Resolve- { connectorName }Error -ErrorObject $ex
+        $errorObj = Resolve-{connectorName}Error -ErrorObject $ex
         $auditMessage = "Could not create or correlate {connectorName} account. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
     } else {

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -79,7 +79,6 @@ try {
     # Process
     switch ($action) {
         'CreateAccount' {
-            Write-Information 'Creating and correlating {connectorName} account'
             $splatCreateParams = @{
                 Uri    = $actionContext.Configuration.BaseUrl
                 Method = 'POST'
@@ -88,10 +87,14 @@ try {
 
             # Make sure to test with special characters and if needed; add utf8 encoding.
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Create logic here
+                Write-Information 'Creating and correlating {connectorName} account'
+                # < Write Create logic here >
+
                 $createdAccount = Invoke-RestMethod @splatCreateParams
                 $outputContext.Data = $createdAccount
                 $outputContext.AccountReference = $createdAccount.Id
+            } else {
+                Write-Information '[DryRun] Create and correlate {connectorName} account, will be executed during enforcement'
             }
             $auditLogMessage = "Create account was successful. AccountReference is: [$($outputContext.AccountReference)]"
             break

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -61,12 +61,13 @@ try {
         }
 
         # Determine if a user needs to be [created] or [correlated]
-        $correlatedAccount = @{                         # Placeholder
+        $correlatedAccount = @{
             Id          = (New-Guid).Guid
             DisplayName = $actionContext.Data.DisplayName
         }
-        # Example (Replace placeholder with actual code):
-        # $correlatedAccount = Invoke-RestMethod @splatGetUser
+        # Example of replacing the placeholder with actual code:
+        # Retrieve user details using an API call and store the result in $correlatedAccount
+        # $correlatedAccount = Invoke-RestMethod @splatGetUserParams
     }
 
     if ($null -ne $correlatedAccount) {
@@ -79,7 +80,7 @@ try {
     switch ($action) {
         'CreateAccount' {
             Write-Information 'Creating and correlating {connectorName} account'
-            $splatParamsCreate = @{
+            $splatCreateParams = @{
                 Uri    = $actionContext.Configuration.BaseUrl
                 Method = 'POST'
                 Body   = $actionContext.Data | ConvertTo-Json
@@ -88,7 +89,7 @@ try {
             # Make sure to test with special characters and if needed; add utf8 encoding.
             if (-not($actionContext.DryRun -eq $true)) {
                 # Write Create logic here
-                $createdAccount = Invoke-RestMethod @splatParamsCreate
+                $createdAccount = Invoke-RestMethod @splatCreateParams
                 $outputContext.Data = $createdAccount
                 $outputContext.AccountReference = $createdAccount.Id
             }

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -61,6 +61,7 @@ try {
         }
 
         # Verify if a user must be either [created ] or just [correlated]
+
         $correlatedAccount = 'userInfo' # Placeholder
         # Example implementation (replace this with actual code):
         # $correlatedAccount = Invoke-RestMethod @splatGetUser

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -7,7 +7,7 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Resolve-{connectorName}Error {
+function Resolve- { connectorName }Error {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -60,10 +60,12 @@ try {
             throw 'Correlation is enabled but [accountFieldValue] is empty. Please make sure it is correctly mapped'
         }
 
-        # Verify if a user must be either [created ] or just [correlated]
-
-        $correlatedAccount = 'userInfo' # Placeholder
-        # Example implementation (replace this with actual code):
+        # Determine if a user needs to be [created] or [correlated]
+        $correlatedAccount = @{                         # Placeholder
+            Id          = (New-Guid).Guid
+            DisplayName = $actionContext.Data.DisplayName
+        }
+        # Example (Replace placeholder with actual code):
         # $correlatedAccount = Invoke-RestMethod @splatGetUser
     }
 
@@ -76,7 +78,7 @@ try {
     # Process
     switch ($action) {
         'CreateAccount' {
-            Write-Information "Creating and correlating {connectorName} account for: [$($personContext.Person.DisplayName)]"
+            Write-Information 'Creating and correlating {connectorName} account'
             $splatParamsCreate = @{
                 Uri    = $actionContext.Configuration.BaseUrl
                 Method = 'POST'
@@ -116,7 +118,7 @@ try {
     $ex = $PSItem
     if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
         $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
-        $errorObj = Resolve-{connectorName}Error -ErrorObject $ex
+        $errorObj = Resolve- { connectorName }Error -ErrorObject $ex
         $auditMessage = "Could not create or correlate {connectorName} account. Error: $($errorObj.FriendlyMessage)"
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
     } else {

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -61,7 +61,9 @@ try {
         }
 
         # Verify if a user must be either [created ] or just [correlated]
-        $correlatedAccount = 'userInfo'
+        $correlatedAccount = 'userInfo' # Placeholder
+        # Example implementation (replace this with actual code):
+        # $correlatedAccount = Invoke-RestMethod @splatGetUser
     }
 
     if ($null -ne $correlatedAccount) {
@@ -74,11 +76,16 @@ try {
     switch ($action) {
         'CreateAccount' {
             Write-Information "Creating and correlating {connectorName} account for: [$($personContext.Person.DisplayName)]"
+            $splatParamsCreate = @{
+                Uri    = $actionContext.Configuration.BaseUrl
+                Method = 'POST'
+                Body   = $actionContext.Data | ConvertTo-Json
+            }
 
             # Make sure to test with special characters and if needed; add utf8 encoding.
             if (-not($actionContext.DryRun -eq $true)) {
                 # Write Create logic here
-                # $createdAccount = Invoke-RestMethod @splatParams
+                $createdAccount = Invoke-RestMethod @splatParamsCreate
                 $outputContext.Data = $createdAccount
                 $outputContext.AccountReference = ''
             }
@@ -90,7 +97,7 @@ try {
             Write-Information 'Correlating {connectorName} account'
 
             $outputContext.Data = $correlatedAccount
-            $outputContext.AccountReference = ''
+            $outputContext.AccountReference = $correlatedAccount
             $outputContext.AccountCorrelated = $true
             $auditLogMessage = "Correlated account: [$($outputContext.AccountReference)] on field: [$($correlationField)] with value: [$($correlationValue)]"
             break

--- a/target/delete.ps1
+++ b/target/delete.ps1
@@ -62,10 +62,12 @@ try {
     # Process
     switch ($action) {
         'DeleteAccount' {
-            Write-Information "Deleting {connectorName} account with accountReference: [$($actionContext.References.Account)]"
-
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Delete logic here
+                Write-Information "Deleting {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+                # < Write Delete logic here >
+
+            } else {
+                Write-Information "[DryRun] Delete {connectorName} account with accountReference: [$($actionContext.References.Account)], will be executed during enforcement"
             }
 
             $outputContext.Success = $true

--- a/target/delete.ps1
+++ b/target/delete.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information 'Verifying if a {connectorName} account exists'
-    $correlatedAccount = 'userInfo' # Placeholder
+    $correlatedAccount = 'userInfo'
 
     if ($null -ne $correlatedAccount) {
         $action = 'DeleteAccount'

--- a/target/delete.ps1
+++ b/target/delete.ps1
@@ -50,7 +50,7 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
+    Write-Information 'Verifying if a {connectorName} account exists'
     $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
@@ -77,10 +77,10 @@ try {
         }
 
         'NotFound' {
-            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
             $outputContext.Success = $true
             $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
                     IsError = $false
                 })
             break

--- a/target/delete.ps1
+++ b/target/delete.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -98,39 +55,35 @@ try {
 
     if ($null -ne $correlatedAccount) {
         $action = 'DeleteAccount'
-        $dryRunMessage = "Delete {connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] will be executed during enforcement"
     } else {
         $action = 'NotFound'
-        $dryRunMessage = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
-    }
-
-    # Add a message and the result of each of the validations showing what will happen during enforcement
-    if ($actionContext.DryRun -eq $true) {
-        Write-Information "[DryRun] $dryRunMessage"
     }
 
     # Process
-    if (-not($actionContext.DryRun -eq $true)) {
-        switch ($action) {
-            'DeleteAccount' {
-                Write-Information "Deleting {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+    switch ($action) {
+        'DeleteAccount' {
+            Write-Information "Deleting {connectorName} account with accountReference: [$($actionContext.References.Account)]"
 
-                $outputContext.Success = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
+            if (-not($actionContext.DryRun -eq $true)) {
+                # Write Delete logic here
+            }
+
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = 'Delete account was successful'
                     IsError = $false
                 })
-                break
-            }
+            break
+        }
 
-            'NotFound' {
-                $outputContext.Success  = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
+        'NotFound' {
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
                     IsError = $false
                 })
-                break
-            }
+            break
         }
     }
 } catch {
@@ -146,7 +99,7 @@ try {
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
     }
     $outputContext.AuditLogs.Add([PSCustomObject]@{
-        Message = $auditMessage
-        IsError = $true
-    })
+            Message = $auditMessage
+            IsError = $true
+        })
 }

--- a/target/delete.ps1
+++ b/target/delete.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
-    $correlatedAccount = 'userInfo'
+    $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
         $action = 'DeleteAccount'

--- a/target/disable.ps1
+++ b/target/disable.ps1
@@ -50,7 +50,7 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
+    Write-Information 'Verifying if a {connectorName} account exists'
     $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
@@ -77,10 +77,10 @@ try {
         }
 
         'NotFound' {
-            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
             $outputContext.Success = $true
             $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
                     IsError = $false
                 })
             break

--- a/target/disable.ps1
+++ b/target/disable.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information 'Verifying if a {connectorName} account exists'
-    $correlatedAccount = 'userInfo' # Placeholder
+    $correlatedAccount = 'userInfo'
 
     if ($null -ne $correlatedAccount) {
         $action = 'DisableAccount'

--- a/target/disable.ps1
+++ b/target/disable.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
-    $correlatedAccount = 'userInfo'
+    $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
         $action = 'DisableAccount'

--- a/target/disable.ps1
+++ b/target/disable.ps1
@@ -62,10 +62,12 @@ try {
     # Process
     switch ($action) {
         'DisableAccount' {
-            Write-Information "Disabling {connectorName} account with accountReference: [$($actionContext.References.Account)]"
-
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Disable logic here
+                Write-Information "Disabling {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+                # < Write Disable logic here >
+
+            } else {
+                Write-Information "[DryRun] Disable {connectorName} account with accountReference: [$($actionContext.References.Account)], will be executed during enforcement"
             }
 
             $outputContext.Success = $true

--- a/target/enable.ps1
+++ b/target/enable.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
-    $correlatedAccount = 'userInfo'
+    $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
         $action = 'EnableAccount'

--- a/target/enable.ps1
+++ b/target/enable.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -98,41 +55,38 @@ try {
 
     if ($null -ne $correlatedAccount) {
         $action = 'EnableAccount'
-        $dryRunMessage = "Enable {connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] will be executed during enforcement"
     } else {
         $action = 'NotFound'
-        $dryRunMessage = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
-    }
-
-    # Add a message and the result of each of the validations showing what will happen during enforcement
-    if ($actionContext.DryRun -eq $true) {
-        Write-Information "[DryRun] $dryRunMessage"
     }
 
     # Process
-    if (-not($actionContext.DryRun -eq $true)) {
-        switch ($action) {
-            'EnableAccount' {
-                Write-Information "Enabling {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+    switch ($action) {
+        'EnableAccount' {
+            Write-Information "Enabling {connectorName} account with accountReference: [$($actionContext.References.Account)]"
 
-                $outputContext.Success = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
+            if (-not($actionContext.DryRun -eq $true)) {
+                # Write Enable logic here
+            }
+
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = 'Enable account was successful'
                     IsError = $false
                 })
-                break
-            }
+            break
+        }
 
-            'NotFound' {
-                $outputContext.Success  = $false
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
+        'NotFound' {
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            $outputContext.Success = $false
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
                     IsError = $true
                 })
-                break
-            }
+            break
         }
     }
+
 } catch {
     $outputContext.success = $false
     $ex = $PSItem

--- a/target/enable.ps1
+++ b/target/enable.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information 'Verifying if a {connectorName} account exists'
-    $correlatedAccount = 'userInfo' # Placeholder
+    $correlatedAccount = 'userInfo'
 
     if ($null -ne $correlatedAccount) {
         $action = 'EnableAccount'

--- a/target/enable.ps1
+++ b/target/enable.ps1
@@ -50,7 +50,7 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
+    Write-Information 'Verifying if a {connectorName} account exists'
     $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
@@ -77,10 +77,10 @@ try {
         }
 
         'NotFound' {
-            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
             $outputContext.Success = $false
             $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
                     IsError = $true
                 })
             break

--- a/target/enable.ps1
+++ b/target/enable.ps1
@@ -62,10 +62,12 @@ try {
     # Process
     switch ($action) {
         'EnableAccount' {
-            Write-Information "Enabling {connectorName} account with accountReference: [$($actionContext.References.Account)]"
-
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Enable logic here
+                Write-Information "Enabling {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+                # < Write Enable logic here >
+
+            } else {
+                Write-Information "[DryRun] Enable {connectorName} account with accountReference: [$($actionContext.References.Account)], will be executed during enforcement"
             }
 
             $outputContext.Success = $true

--- a/target/fieldMapping.json
+++ b/target/fieldMapping.json
@@ -107,48 +107,6 @@
       ]
     },
     {
-      "Name": "StartDate",
-      "Description": "Set the start date to \"now\" in HelloID to manage it in the target system. Using the contract start date can cause login issues, even without an end date.",
-      "Type": "Text",
-      "MappingActions": [
-        {
-          "MapForActions": [
-            "Create"
-          ],
-          "MappingMode": "Complex",
-          "Value": "\"function getValue() {\\n    let date = new Date();\\n    return  date.toISOString().split('T')[0]\\n}\\n\\n\\n\\n\\n\\n\\ngetValue();\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": false
-        }
-      ]
-    },
-    {
-      "Name": "EndDate",
-      "Description": "The end date is mostly essential for disabling an account. During creation, the account is set to disabled by adding an end date of yesterday. To enable the account, simply remove the end date.",
-      "Type": "Text",
-      "MappingActions": [
-        {
-          "MapForActions": [
-            "Create",
-            "Disable"
-          ],
-          "MappingMode": "Complex",
-          "Value": "\"function getValue() {\\r\\n    let date = new Date();\\r\\n    date.setDate(date.getDate() - 1);\\r\\n    return date.toISOString().split('T')[0]\\r\\n}\\r\\ngetValue();\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": false
-        },
-        {
-          "MapForActions": [
-            "Enable"
-          ],
-          "MappingMode": "None",
-          "Value": "\"\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": false
-        }
-      ]
-    },
-    {
       "Name": "Manager",
       "Description": "",
       "Type": "Text",

--- a/target/permissions/groups/grantPermission.ps1
+++ b/target/permissions/groups/grantPermission.ps1
@@ -52,7 +52,7 @@ try {
     }
 
     Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
-    $correlatedAccount = 'userInfo'
+    $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
         $action = 'GrantPermission'

--- a/target/permissions/groups/grantPermission.ps1
+++ b/target/permissions/groups/grantPermission.ps1
@@ -63,11 +63,14 @@ try {
     # Process
     switch ($action) {
         'GrantPermission' {
-            Write-Information "Granting {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
 
             # Make sure to test with special characters and if needed; add utf8 encoding.
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Grant Permission logic here
+                Write-Information "Granting {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
+                # < Write Grant Permission logic here >
+
+            } else {
+                Write-Information "[DryRun] Grant {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)], will be executed during enforcement"
             }
 
             $outputContext.Success = $true

--- a/target/permissions/groups/grantPermission.ps1
+++ b/target/permissions/groups/grantPermission.ps1
@@ -51,7 +51,7 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
+    Write-Information 'Verifying if a {connectorName} account exists'
     $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
@@ -78,10 +78,10 @@ try {
         }
 
         'NotFound' {
-            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
             $outputContext.Success  = $false
             $outputContext.AuditLogs.Add([PSCustomObject]@{
-                Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+                Message = "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
                 IsError = $true
             })
             break

--- a/target/permissions/groups/grantPermission.ps1
+++ b/target/permissions/groups/grantPermission.ps1
@@ -52,7 +52,7 @@ try {
     }
 
     Write-Information 'Verifying if a {connectorName} account exists'
-    $correlatedAccount = 'userInfo' # Placeholder
+    $correlatedAccount = 'userInfo'
 
     if ($null -ne $correlatedAccount) {
         $action = 'GrantPermission'

--- a/target/permissions/groups/grantPermission.ps1
+++ b/target/permissions/groups/grantPermission.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -99,40 +56,35 @@ try {
 
     if ($null -ne $correlatedAccount) {
         $action = 'GrantPermission'
-        $dryRunMessage = "Grant {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] will be executed during enforcement"
     } else {
         $action = 'NotFound'
-        $dryRunMessage = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
-    }
-
-    # Add a message and the result of each of the validations showing what will happen during enforcement
-    if ($actionContext.DryRun -eq $true) {
-        Write-Information "[DryRun] $dryRunMessage"
     }
 
     # Process
-    if (-not($actionContext.DryRun -eq $true)) {
-        switch ($action) {
-            'GrantPermission' {
-                Write-Information "Granting {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
+    switch ($action) {
+        'GrantPermission' {
+            Write-Information "Granting {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
 
-                # Make sure to test with special characters and if needed; add utf8 encoding.
-        
-                $outputContext.Success = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "Grant permission [$($actionContext.References.Permission.DisplayName)] was successful"
-                    IsError = $false
-                })
+            # Make sure to test with special characters and if needed; add utf8 encoding.
+            if (-not($actionContext.DryRun -eq $true)) {
+                # Write Grant Permission logic here
             }
 
-            'NotFound' {
-                $outputContext.Success  = $false
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
-                    IsError = $true
-                })
-                break
-            }
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                Message = "Grant permission [$($actionContext.References.Permission.DisplayName)] was successful"
+                IsError = $false
+            })
+        }
+
+        'NotFound' {
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            $outputContext.Success  = $false
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+                IsError = $true
+            })
+            break
         }
     }
 } catch {

--- a/target/permissions/groups/permissions.ps1
+++ b/target/permissions/groups/permissions.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -91,12 +48,12 @@ try {
     Write-Information 'Retrieving permissions'
     $retrievedPermissions = @(
         @{
-            Name = 'Permission-1'
-            id   = (New-Guid)
+            name = 'Permission-1'
+            id   = "$(New-Guid)"
         },
         @{
-            Name = 'Permission-2'
-            id   = (New-Guid)
+            name = 'Permission-2'
+            id   = "$(New-Guid)"
         }
     )
 

--- a/target/permissions/groups/revokePermission.ps1
+++ b/target/permissions/groups/revokePermission.ps1
@@ -51,7 +51,7 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
+    Write-Information 'Verifying if a {connectorName} account exists'
     $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
@@ -78,10 +78,10 @@ try {
         }
 
         'NotFound' {
-            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
             $outputContext.Success = $true
             $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
                     IsError = $false
                 })
             break

--- a/target/permissions/groups/revokePermission.ps1
+++ b/target/permissions/groups/revokePermission.ps1
@@ -52,7 +52,7 @@ try {
     }
 
     Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
-    $correlatedAccount = 'userInfo'
+    $correlatedAccount = 'userInfo' # Placeholder
 
     if ($null -ne $correlatedAccount) {
         $action = 'RevokePermission'

--- a/target/permissions/groups/revokePermission.ps1
+++ b/target/permissions/groups/revokePermission.ps1
@@ -63,11 +63,14 @@ try {
     # Process
     switch ($action) {
         'RevokePermission' {
-            Write-Information "Revoking {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
 
             # Make sure to test with special characters and if needed; add utf8 encoding.
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Revoke Permission logic here
+                Write-Information "Revoking {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
+                # < Write Revoke Permission logic here >
+
+            } else {
+                Write-Information "[DryRun] Revoke {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)], will be executed during enforcement"
             }
 
             $outputContext.Success = $true

--- a/target/permissions/groups/revokePermission.ps1
+++ b/target/permissions/groups/revokePermission.ps1
@@ -52,7 +52,7 @@ try {
     }
 
     Write-Information 'Verifying if a {connectorName} account exists'
-    $correlatedAccount = 'userInfo' # Placeholder
+    $correlatedAccount = 'userInfo'
 
     if ($null -ne $correlatedAccount) {
         $action = 'RevokePermission'

--- a/target/permissions/groups/revokePermission.ps1
+++ b/target/permissions/groups/revokePermission.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -99,38 +56,35 @@ try {
 
     if ($null -ne $correlatedAccount) {
         $action = 'RevokePermission'
-        $dryRunMessage = "Revoke {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] will be executed during enforcement"
     } else {
         $action = 'NotFound'
-        $dryRunMessage = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
-    }
-
-    # Add a message and the result of each of the validations showing what will happen during enforcement
-    if ($actionContext.DryRun -eq $true) {
-        Write-Information "[DryRun] $dryRunMessage"
     }
 
     # Process
-    if (-not($actionContext.DryRun -eq $true)) {
-        switch ($action) {
-            'RevokePermission' {
-                Write-Information "Revoking {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
+    switch ($action) {
+        'RevokePermission' {
+            Write-Information "Revoking {connectorName} permission: [$($actionContext.References.Permission.DisplayName)] - [$($actionContext.References.Permission.Reference)]"
 
-                $outputContext.Success = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
+            # Make sure to test with special characters and if needed; add utf8 encoding.
+            if (-not($actionContext.DryRun -eq $true)) {
+                # Write Revoke Permission logic here
+            }
+
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = "Revoke permission [$($actionContext.References.Permission.DisplayName)] was successful"
                     IsError = $false
                 })
-            }
+        }
 
-            'NotFound' {
-                $outputContext.Success  = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
+        'NotFound' {
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
                     IsError = $false
                 })
-                break
-            }
+            break
         }
     }
 } catch {

--- a/target/resources/groups/resources.ps1
+++ b/target/resources/groups/resources.ps1
@@ -53,12 +53,15 @@ try {
 
             # If resource does not exist
             if ($True) {
-                Write-Information "Create [$($resource)] {connectorName} resource"
-
                 # Make sure to test with special characters and if needed; add utf8 encoding.
                 if (-not ($actionContext.DryRun -eq $True)) {
-                    # Write resource creation logic here
+                    Write-Information "Create [$($resource)] {connectorName} resource"
+                    # < Write resource creation logic here >
+
+                } else {
+                    Write-Information "[DryRun] Create {connectorName} [$($resource)] resource, will be executed during enforcement"
                 }
+
                 $outputContext.AuditLogs.Add([PSCustomObject]@{
                         Message =  "Created resource: [$($resource)]"
                         IsError = $false

--- a/target/resources/groups/resources.ps1
+++ b/target/resources/groups/resources.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -96,17 +53,16 @@ try {
 
             # If resource does not exist
             if ($True) {
+                Write-Information "Create [$($resource)] {connectorName} resource"
+
+                # Make sure to test with special characters and if needed; add utf8 encoding.
                 if (-not ($actionContext.DryRun -eq $True)) {
                     # Write resource creation logic here
-                    # Make sure to test with special characters and if needed; add utf8 encoding.
-
-                    $outputContext.AuditLogs.Add([PSCustomObject]@{
+                }
+                $outputContext.AuditLogs.Add([PSCustomObject]@{
                         Message =  "Created resource: [$($resource)]"
                         IsError = $false
                     })
-                } else {
-                    Write-Information "[DryRun] Create [$($resource)] {connectorName} resource, will be executed during enforcement"
-                }
             }
         } catch {
             $outputContext.Success =$false

--- a/target/test/actionContext.json
+++ b/target/test/actionContext.json
@@ -1,0 +1,33 @@
+{
+    "Configuration": {
+        "UserName": "",
+        "Password": "",
+        "BaseUrl": ""
+    },
+    "DryRun": true,
+    "Operation": "undefined",
+    "Data": {
+        "EndDate": "2025-10-22T10:28:05.2085206",
+        "NickName": "Casey",
+        "Title": "Central Web Engineer",
+        "Department": "Legal",
+        "DisplayName": null,
+        "ExternalId": "123456789",
+        "Manager": "Carl Dijk",
+        "FamilyName": "Bos",
+        "StartDate": "2021-01-01T23:09:08.2863496",
+        "UserName": "casey.bos1"
+      },
+    "CorrelationConfiguration": {
+        "Enabled": true,
+        "PersonField": "Person.ExternalId",
+        "PersonFieldValue": "123456789",
+        "AccountField": "ExternalId",
+        "AccountFieldValue": "123456789"
+    },
+    "AccountCorrelated": false,
+    "References": {
+        "Account": null,
+        "ManagerAccount": null
+    }
+}

--- a/target/test/actionContext.json
+++ b/target/test/actionContext.json
@@ -8,7 +8,7 @@
     "Operation": "undefined",
     "Data": {
         "EndDate": "2025-10-22T10:28:05.2085206",
-        "NickName": "Casey",
+        "NickName": "Cásey",
         "Title": "Central Web Engineer",
         "Department": "Legal",
         "DisplayName": null,

--- a/target/test/config.json
+++ b/target/test/config.json
@@ -1,5 +1,0 @@
-{
-    "UserName":  "",
-    "BaseUrl":  "",
-    "Password":  ""
-}

--- a/target/test/debugStart.ps1
+++ b/target/test/debugStart.ps1
@@ -9,10 +9,7 @@ $VerbosePreference = 'SilentlyContinue'
 $InformationPreference = 'Continue'
 
 $personContext = @{Person = (Get-Content '{folderPath}/demoPerson.json' -Encoding 'UTF8' | ConvertFrom-Json) }
-$actionContext = Get-Content '{folderPath}/demoPerson.json'  -Encoding 'UTF8' | ConvertFrom-Json
-
-# $config = (Get-Content '{folderPath}/config.json'| ConvertFrom-Json)
-# $actionContext.Configuration = $config
+$actionContext = Get-Content '{folderPath}/actionContext.json'  -Encoding 'UTF8' | ConvertFrom-Json
 
 # The 'CustomList' is a wrapper class around '[System.Collections.Generic.List].
 # Its being used in the 'outputContext.AuditLogs'.

--- a/target/test/debugStart.ps1
+++ b/target/test/debugStart.ps1
@@ -9,7 +9,7 @@ $VerbosePreference = 'SilentlyContinue'
 $InformationPreference = 'Continue'
 
 $personContext = @{Person = (Get-Content '{folderPath}/demoPerson.json' -Encoding 'UTF8' | ConvertFrom-Json) }
-$actionContext = Get-Content '{folderPath}/actionContext.json'  -Encoding 'UTF8' | ConvertFrom-Json
+$actionContext = Get-Content '{folderPath}/actionContext.json' -Encoding 'UTF8' | ConvertFrom-Json
 
 # The 'CustomList' is a wrapper class around '[System.Collections.Generic.List].
 # Its being used in the 'outputContext.AuditLogs'.

--- a/target/test/debugStart.ps1
+++ b/target/test/debugStart.ps1
@@ -4,41 +4,15 @@
 #####################################################
 
 # Select the code below and press F8 to initialize the variable(s) in your PSSession
-$warningPreference = 'Continue'
-$VerbosePreference = 'Continue'
+$WarningPreference = 'Continue'
+$VerbosePreference = 'SilentlyContinue'
 $InformationPreference = 'Continue'
-$config = (Get-Content '{folderPath}/config.json'| ConvertFrom-Json)
-$personContext = @{Person = (Get-Content '{folderPath}/demoPerson.json'| ConvertFrom-Json)}
 
-$actionContext = @{
-    Configuration = $config
-    DryRun        = $false
-    Operation     = 'undefined'
-    Data = @{
-        Department  = $($personContext.person.PrimaryContract.Department.DisplayName)
-        DisplayName = $($personContext.Person.Name.DisplayName)
-        EndDate     = $($personContext.person.PrimaryContract.EndDate)
-        ExternalId  = $($personContext.Person.ExternalId)
-        FamilyName  = $($personContext.Person.Name.FamilyName)
-        Manager     = $($personContext.person.PrimaryManager.DisplayName)
-        NickName    = $($personContext.Person.Name.NickName)
-        StartDate   = $($personContext.person.PrimaryContract.StartDate)
-        Title       = $($personContext.person.PrimaryContract.Title.Name)
-        UserName    = 'casey.bos1'
-    }
-    CorrelationConfiguration = @{
-        Enabled           = $true
-        PersonField       = 'Person.ExternalId'
-        PersonFieldValue  = $($personContext.Person.ExternalId)
-        AccountField      = 'externalId'
-        AccountFieldValue = $($personContext.Person.ExternalId)
-    }
-    AccountCorrelated = $true
-    References = @{
-        Account        = ''
-        ManagerAccount = ''
-    }
-}
+$personContext = @{Person = (Get-Content '{folderPath}/demoPerson.json' -Encoding 'UTF8' | ConvertFrom-Json) }
+$actionContext = Get-Content '{folderPath}/demoPerson.json'  -Encoding 'UTF8' | ConvertFrom-Json
+
+# $config = (Get-Content '{folderPath}/config.json'| ConvertFrom-Json)
+# $actionContext.Configuration = $config
 
 # The 'CustomList' is a wrapper class around '[System.Collections.Generic.List].
 # Its being used in the 'outputContext.AuditLogs'.
@@ -48,7 +22,7 @@ class CustomList {
     [void] Add([object] $obj) {
         $this.list.Add($obj)
         $scriptBlock = {
-            if ($obj.IsError){
+            if ($obj.IsError) {
                 $psEditor.Window.ShowErrorMessage("Message: [$($obj.Message)]. Action: [$($obj.Action)]")
             } else {
                 $psEditor.Window.ShowInformationMessage("Message: [$($obj.Message)]. Action: [$($obj.Action)]")
@@ -59,7 +33,7 @@ class CustomList {
     }
 }
 
-$outputContext = @{
+$outputContext = [PSCustomObject]@{
     Data              = $null
     PreviousData      = $null
     AuditLogs         = [CustomList]::new()

--- a/target/update.ps1
+++ b/target/update.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information 'Verifying if a {connectorName} account exists'
-    $correlatedAccount = 'userInfo' # Placeholder
+    $correlatedAccount = 'userInfo'
     $outputContext.PreviousData = $correlatedAccount
 
     # Always compare the account against the current account in target system

--- a/target/update.ps1
+++ b/target/update.ps1
@@ -7,49 +7,6 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
 #region functions
-function Invoke-{connectorName}RestMethod {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Uri,
-
-        [object]
-        $Body,
-
-        [string]
-        $ContentType = 'application/json',
-
-        [Parameter(Mandatory)]
-        [System.Collections.IDictionary]
-        $Headers
-    )
-
-    process {
-        try {
-            $splatParams = @{
-                Uri         = $Uri
-                Headers     = $Headers
-                Method      = $Method
-                ContentType = $ContentType
-            }
-
-            if ($Body){
-                $splatParams['Body'] = $Body
-            }
-            Invoke-RestMethod @splatParams -Verbose:$false
-        } catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-    }
-}
-
 function Resolve-{connectorName}Error {
     [CmdletBinding()]
     param (
@@ -102,60 +59,55 @@ try {
         $splatCompareProperties = @{
             ReferenceObject  = @($correlatedAccount.PSObject.Properties)
             DifferenceObject = @($actionContext.Data.PSObject.Properties)
-        }  
+        }
         $propertiesChanged = Compare-Object @splatCompareProperties -PassThru | Where-Object { $_.SideIndicator -eq '=>' }
         if ($propertiesChanged) {
             $action = 'UpdateAccount'
-            $dryRunMessage = "Account property(s) required to update: $($propertiesChanged.Name -join ', ')"
         } else {
             $action = 'NoChanges'
-            $dryRunMessage = 'No changes will be made to the account during enforcement'
         }
     } else {
         $action = 'NotFound'
-        $dryRunMessage = "{connectorName} account for: [$($personContext.Person.DisplayName)] not found. Possibly deleted."
-    }
-
-    # Add a message and the result of each of the validations showing what will happen during enforcement
-    if ($actionContext.DryRun -eq $true) {
-        Write-Information "[DryRun] $dryRunMessage"
     }
 
     # Process
-    if (-not($actionContext.DryRun -eq $true)) {
-        switch ($action) {
-            'UpdateAccount' {
-                Write-Information "Updating {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+    switch ($action) {
+        'UpdateAccount' {
+            Write-Information "Updating {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+            Write-Information "Account property(s) required to update: $($propertiesChanged.Name -join ', ')"
 
-                # Make sure to test with special characters and if needed; add utf8 encoding.
+            # Make sure to test with special characters and if needed; add utf8 encoding.
+            if (-not($actionContext.DryRun -eq $true)) {
+                # Write Update logic here
+            }
 
-                $outputContext.Success = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = "Update account was successful, Account property(s) updated: [$($propertiesChanged.name -join ',')]"
                     IsError = $false
                 })
-                break
-            }
+            break
+        }
 
-            'NoChanges' {
-                Write-Information "No changes to {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+        'NoChanges' {
+            Write-Information "No changes to {connectorName} account with accountReference: [$($actionContext.References.Account)]"
 
-                $outputContext.Success = $true
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
+            $outputContext.Success = $true
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = 'No changes will be made to the account during enforcement'
                     IsError = $false
                 })
-                break
-            }
+            break
+        }
 
-            'NotFound' {
-                $outputContext.Success  = $false
-                $outputContext.AuditLogs.Add([PSCustomObject]@{
-                    Message = "{connectorName} account with accountReference: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted, or the account is not correlated"
+        'NotFound' {
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            $outputContext.Success = $false
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    Message = "{connectorName} account with accountReference: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
                     IsError = $true
                 })
-                break
-            }
+            break
         }
     }
 } catch {

--- a/target/update.ps1
+++ b/target/update.ps1
@@ -73,12 +73,15 @@ try {
     # Process
     switch ($action) {
         'UpdateAccount' {
-            Write-Information "Updating {connectorName} account with accountReference: [$($actionContext.References.Account)]"
             Write-Information "Account property(s) required to update: $($propertiesChanged.Name -join ', ')"
 
             # Make sure to test with special characters and if needed; add utf8 encoding.
             if (-not($actionContext.DryRun -eq $true)) {
-                # Write Update logic here
+                Write-Information "Updating {connectorName} account with accountReference: [$($actionContext.References.Account)]"
+                # < Write Update logic here >
+
+            } else {
+                Write-Information "[DryRun] Update {connectorName} account with accountReference: [$($actionContext.References.Account)], will be executed during enforcement"
             }
 
             $outputContext.Success = $true

--- a/target/update.ps1
+++ b/target/update.ps1
@@ -51,7 +51,7 @@ try {
     }
 
     Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
-    $correlatedAccount = 'userInfo'
+    $correlatedAccount = 'userInfo' # Placeholder
     $outputContext.PreviousData = $correlatedAccount
 
     # Always compare the account against the current account in target system

--- a/target/update.ps1
+++ b/target/update.ps1
@@ -50,7 +50,7 @@ try {
         throw 'The account reference could not be found'
     }
 
-    Write-Information "Verifying if a {connectorName} account for [$($personContext.Person.DisplayName)] exists"
+    Write-Information 'Verifying if a {connectorName} account exists'
     $correlatedAccount = 'userInfo' # Placeholder
     $outputContext.PreviousData = $correlatedAccount
 
@@ -101,7 +101,7 @@ try {
         }
 
         'NotFound' {
-            Write-Information "{connectorName} account: [$($actionContext.References.Account)] for person: [$($personContext.Person.DisplayName)] could not be found, possibly indicating that it could be deleted"
+            Write-Information "{connectorName} account: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"
             $outputContext.Success = $false
             $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = "{connectorName} account with accountReference: [$($actionContext.References.Account)] could not be found, possibly indicating that it could be deleted"


### PR DESCRIPTION
### Added
 - Added a default ActionContext.json to use in the DebugStart script. This provides test data for local debugging and can be directly extracted from HelloID, ensuring consistent object handling locally and in HelloID
### Changed
 - Moved the processing DryRun block one level closer to the actual web call. To skip only the web call in the target system in preview mode. To remove the difference between a preview run and actual enforcement. And test more connector code in Preview mode.
 - Changed the debugStart to use ActionContext.json instead of Powershell Object.
 - Some textual improvements.
 - Moved explicit DryRun messages for preview mode, to the `else` condition after the (-not dryrun block).

### Removed
- Removed the Invoke-<connectorName>RestMethod from the template.
- Removed Person.DisplayName from logging.
- Removed Start EndDate from FieldMapping.
