### PR TITLE
Added correlationValue handling to allow empty personField in configu…

### DIFF
--- a/target/create.ps1
+++ b/target/create.ps1
@@ -93,14 +93,24 @@ try {
 
     # Validate correlation configuration
     if ($actionContext.CorrelationConfiguration.Enabled) {
-        $correlationField = $actionContext.CorrelationConfiguration.accountField
-        $correlationValue = $actionContext.CorrelationConfiguration.accountFieldValue
-
-        if ([string]::IsNullOrEmpty($($correlationField))) {
-            throw 'Correlation is enabled but not configured correctly'
+        #Check for correct correlation configuration
+        if ($Null -eq $ActionContext.CorrelationConfiguration.accountField) {
+            throw 'Correlation is enabled but not configured correctly because the accountField is empty'
         }
-        if ([string]::IsNullOrEmpty($($correlationValue))) {
-            throw 'Correlation is enabled but [accountFieldValue] is empty. Please make sure it is correctly mapped'
+
+        $correlationField = $actionContext.CorrelationConfiguration.accountField
+
+        #If no PersonField is configured in the target system, then use the Account field value to fill the correlationValue variable
+        if ($Null -ne $actionContext.CorrelationConfiguration.PersonField) {
+            $correlationValue = $actionContext.CorrelationConfiguration.PersonFieldValue
+        }
+        else {
+            $correlationValue = $actionContext.CorrelationConfiguration.AccountFieldValue
+        }
+
+        #If the correlationValue is empty throw an error
+        if ([string]::IsNullOrEmpty($CorrelationValue)) {
+            throw 'Correlation is enabled but the correlation value is empty'
         }
 
         # Verify if a user must be either [created ] or just [correlated]

--- a/target/create.ps1
+++ b/target/create.ps1
@@ -93,20 +93,19 @@ try {
 
     # Validate correlation configuration
     if ($actionContext.CorrelationConfiguration.Enabled) {
-        #Check for correct correlation configuration
-        if ($Null -eq $ActionContext.CorrelationConfiguration.accountField) {
-            throw 'Correlation is enabled but not configured correctly because the accountField is empty'
+        #Check for correct correlation configuration (account field should be configured)
+        if ($Null -eq $ActionContext.CorrelationConfiguration.AccountField) {
+            throw 'Correlation is enabled but not configured correctly because the Account Correlation Field is empty'
         }
 
-        $correlationField = $actionContext.CorrelationConfiguration.accountField
+        $correlationField = $actionContext.CorrelationConfiguration.AccountField
 
-        #If no PersonField is configured in the target system, then use the Account field value to fill the correlationValue variable
-        if ($Null -ne $actionContext.CorrelationConfiguration.PersonField) {
-            $correlationValue = $actionContext.CorrelationConfiguration.PersonFieldValue
+        #Check for correct correlation configuration (person field should be configured)
+        if ($Null -eq $ActionContext.CorrelationConfiguration.PersonField) {
+            throw 'Correlation is enabled but not configured correctly because the Person Correlation Field is empty'
         }
-        else {
-            $correlationValue = $actionContext.CorrelationConfiguration.AccountFieldValue
-        }
+
+        $correlationValue = $actionContext.CorrelationConfiguration.PersonFieldValue
 
         #If the correlationValue is empty throw an error
         if ([string]::IsNullOrEmpty($CorrelationValue)) {


### PR DESCRIPTION
…ration tab

The configuration of the V2 PowerShell system allows the Person Correlation Field to remain empty. This is usefull for correlation accounts in systems like Entra Id where the local user has already been created by HelloID. If the Person Correlation Field is empty then the data of the AccountField data will be used to correlate a user in the target system.

The accountField itself is always required